### PR TITLE
Fix CollectionChangeCallback typing

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -37,7 +37,7 @@ declare namespace Realm {
         oldModifications: Object[];
     }
 
-    type CollectionChangeCallback<T> = (collection: Collection<T>, change: ObjectChanges) => void;
+    type CollectionChangeCallback<T> = (collection: Collection<T>, change: CollectionChangeSet) => void;
 
     /**
      * PropertyType


### PR DESCRIPTION
Changed CollectionChangeCallback 'change' param to CollectionChangeSet instead of ObjectChanges.

It was probably a typo, but the param 'change' for CollectionChangeCallback was ObjectChanges instead of CollectionChangeSet. This messes with the typescript when the dev tries to create a callback listener function. 

*If this PR adds or changes public API's:*
* [x] typescript definitions file is updated
